### PR TITLE
Upgrade to Killbill v0.18.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-email-notifications-plugin</artifactId>
     <name>Kill Bill OSGI Email Notifications Plugin</name>
-    <version>0.2.1-WOMPLY-SNAPSHOT</version>
+    <version>0.3.1-WOMPLY-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Kill Bill Email Notifications Plugin</description>
     <url>http://github.com/killbill/killbill-email-notifications-plugin</url>


### PR DESCRIPTION
- Rebased on killbill/master which brought in the changes to upgrade to KillBill version 0.18.4
- Changed the pom version to `0.3.1-WOMPLY-SNAPSHOT`